### PR TITLE
Update gemspec for grape ~> 3.1 and Ruby >= 3.1

### DIFF
--- a/grape-cache.gemspec
+++ b/grape-cache.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
     'source_code_uri' => 'https://github.com/netrusov/grape-cache'
   }
 
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.1.0'
 
   spec.add_runtime_dependency 'activesupport'
-  spec.add_runtime_dependency 'grape', '>= 1.2', '< 2'
+  spec.add_runtime_dependency 'grape', '>= 3.1', '< 4'
   spec.add_runtime_dependency 'rack'
 end


### PR DESCRIPTION
## Summary

- Relaxes grape dependency from `'>= 1.2', '< 2'` to `'>= 3.1', '< 4'` to support Grape 3.x
- Updates `required_ruby_version` from `>= 2.6.0` to `>= 3.1.0`

Required as a companion to the Homer Ruby 4.0.2 upgrade (AkiraMD/homer#9616).

## Test plan

- [ ] Bundled into Homer via `path:` reference in Gemfile — CI on the Homer PR validates integration
- [ ] After merge, Homer Gemfile can revert `grape-cache` from `path: '../grape-cache'` back to `github: 'AkiraMD/grape-cache'`